### PR TITLE
新增选项: 是否下载原图

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import httpx
 import asyncio
 import os
 import json
+import sys
+sys.path.append('.')
 from user_info import User_info
 from csv_gen import csv_gen
 from cache_gen import cache_gen
@@ -49,6 +51,9 @@ down_log = False
 async_down = True
 autoSync = False
 
+orig_format = False # 尝试原图下载
+orig_fail_alert = False # 开启原图下载错误的提示
+
 start_time_stamp = 655028357000   #1990-10-04
 end_time_stamp = 2548484357000    #2050-10-04
 start_label = True
@@ -89,8 +94,16 @@ with open('settings.json', 'r', encoding='utf8') as f:
         proxies = settings['proxy']
     else:
         proxies = None
+
 ############
     img_format = settings['img_format']
+    
+    if settings['orig_format']:
+        orig_format = settings['orig_format']
+        img_format = 'jpg'
+    if settings['orig_fail_alert']:
+        orig_fail_alert = settings['orig_fail_alert']
+
     f.close()
 
 backup_stamp = start_time_stamp
@@ -293,17 +306,20 @@ def download_control(_user_info):
             else:
                 try:
                     _file_name = f'{_user_info.save_path + os.sep}{prefix}_{_user_info.count + order}.{img_format}'
-                    url += f'?format={img_format}&name=4096x4096'
+                    url += f'?format={img_format}&name=orig'
                 except Exception as e:
                     print(url)
                     return False
             count = 0
+            orig_fail = 0 # 0-原图下载成功 或未开启原图下载  1-PNG原图下载失败，尝试JPEG原图下载  2-原图下载失败，尝试使用name=4096x4096下载
             while True:
                 try:
                     async with semaphore:
                         async with httpx.AsyncClient(proxy=proxies) as client:
                             global down_count
                             response = await client.get(quote_url(url), timeout=(3.05, 16))        #如果出现第五次或以上的下载失败,且确认不是网络问题,可以适当降低最大并发数量
+                            if response.status_code == 404:
+                                raise Exception('404')
                             down_count += 1
                     with open(_file_name,'wb') as f:
                         f.write(response.content)
@@ -317,9 +333,24 @@ def download_control(_user_info):
             
                     break
                 except Exception as e:
-                    count += 1
-                    print(f'{_file_name}=====>第{count}次下载失败,正在重试(多次失败时请降低main.py第11行-异步模式)')
-                    print(url)
+                    if '.mp4' in url or not orig_format or orig_fail == 2:
+                        count += 1
+                        print(f'{_file_name}=====>第{count}次下载失败,正在重试(多次失败时请降低main.py第11行-异步模式)')
+                        print(url)
+                    if orig_format:
+                        if orig_fail == 0:
+                            orig_fail = 1
+                            if orig_fail_alert:
+                                print(f'{_file_name}=====>JPEG 格式的原图下载失败, 正在尝试使用 PNG 格式。({repr(e)})')
+                                print(url)
+                            url = url.replace('format=jpg', 'format=png')
+                            _file_name = re.sub(r'jpg$', "png", _file_name)
+                        elif orig_fail == 1: # 一般不会遇到下面这种情况
+                            orig_fail = 2
+                            url = url.replace('name=orig', 'name=4096x4096')
+                            if orig_fail_alert:
+                                print(f'{_file_name}=====>原图下载失败, 正在下载其最大分辨率(小于4K)。({repr(e)})')
+                                print(url)
 
         while True:
             photo_lst = get_download_url(_user_info)

--- a/main.py
+++ b/main.py
@@ -6,11 +6,13 @@ import asyncio
 import os
 import json
 import sys
-sys.path.append('.')
+
 from user_info import User_info
 from csv_gen import csv_gen
 from cache_gen import cache_gen
 from url_utils import quote_url
+
+sys.path.append('.')
 
 max_concurrent_requests = 8     #最大并发数量，默认为8，对自己网络有自信的可以调高; 遇到多次下载失败时适当降低
 

--- a/main.py
+++ b/main.py
@@ -333,11 +333,11 @@ def download_control(_user_info):
             
                     break
                 except Exception as e:
-                    if '.mp4' in url or not orig_format or orig_fail == 2:
+                    if '.mp4' in url or not orig_format or str(e) != "404":
                         count += 1
                         print(f'{_file_name}=====>第{count}次下载失败,正在重试(多次失败时请降低main.py第16行-异步模式)')
                         print(url)
-                    if orig_format:
+                    elif orig_format:
                         if orig_fail == 0:
                             orig_fail = 1
                             url = url.replace('format=jpg', 'format=png')

--- a/main.py
+++ b/main.py
@@ -7,12 +7,13 @@ import os
 import json
 import sys
 
+sys.path.append('.')
 from user_info import User_info
 from csv_gen import csv_gen
 from cache_gen import cache_gen
 from url_utils import quote_url
 
-sys.path.append('.')
+
 
 max_concurrent_requests = 8     #最大并发数量，默认为8，对自己网络有自信的可以调高; 遇到多次下载失败时适当降低
 
@@ -102,7 +103,7 @@ with open('settings.json', 'r', encoding='utf8') as f:
     
     if settings['orig_format']:
         orig_format = settings['orig_format']
-        img_format = 'jpg'
+        img_format = 'jpg';
     if settings['orig_fail_alert']:
         orig_fail_alert = settings['orig_fail_alert']
 
@@ -308,7 +309,10 @@ def download_control(_user_info):
             else:
                 try:
                     _file_name = f'{_user_info.save_path + os.sep}{prefix}_{_user_info.count + order}.{img_format}'
-                    url += f'?format={img_format}&name=orig'
+                    if orig_format:
+                        url += f'?format=jpg&name=orig'
+                    else:
+                        url += f'?format={img_format}&name=4096x4096'
                 except Exception as e:
                     print(url)
                     return False
@@ -342,11 +346,11 @@ def download_control(_user_info):
                     if orig_format:
                         if orig_fail == 0:
                             orig_fail = 1
+                            url = url.replace('format=jpg', 'format=png')
+                            _file_name = re.sub(r'jpg$', "png", _file_name)
                             if orig_fail_alert:
                                 print(f'{_file_name}=====>JPEG 格式的原图下载失败, 正在尝试使用 PNG 格式。({repr(e)})')
                                 print(url)
-                            url = url.replace('format=jpg', 'format=png')
-                            _file_name = re.sub(r'jpg$', "png", _file_name)
                         elif orig_fail == 1: # 一般不会遇到下面这种情况
                             orig_fail = 2
                             url = url.replace('name=orig', 'name=4096x4096')

--- a/settings.json
+++ b/settings.json
@@ -47,6 +47,11 @@
     "proxy": "",
     "proxy_info": "手动配置代理,默认为空,非必要无需填写 格式: http://localhost:port ",
 
+    "orig_format": true,
+    "orig_format_info": "忽略 img_format 并依次尝试以 JPEG, PNG 格式下载原图 (name=orig) 。均下载错误后会退回使用 PNG name=4096x4096 进行下载)",
+
+    "orig_fail_alert": true,
+    "orig_fail_alert_info": "开启原图下载错误的提示",
 
     "(๑´ڡ`๑)": "info 是注释，凑合着看吧"
 }

--- a/settings.json
+++ b/settings.json
@@ -32,8 +32,8 @@
     "autoSync": false,
     "autoSync_info": "开启后将基于本地已有的内容自动同步最新的部分, 本质上是自动调整时间范围的左半部分, 右半建议2030-01-01或更长",
 
-    "img_format": "png",
-    "img_format_info": "下载图片/视频的质量(png为高质量,jpg为标准质量)",
+    "orig_format": true,
+    "orig_format_info": "开启后将依次尝试以 JPEG, PNG 格式下载原图 (name=orig) ，均下载错误后会退回使用 PNG name=4096x4096 进行下载)。关闭时则全部使用 JPEG 格式，且不超过 4K 的分辨率进行下载。",
 
     "has_video": true,
     "has_video_info": "是否下载推文中的视频",
@@ -42,16 +42,10 @@
     "log_output_info": "是否需要下载过程日志输出",
 
     "async_down": true,
-    "async_down_info": "异步下载,默认开启,网络不好时可以关闭,并发数量可在主函数11行修改",
+    "async_down_info": "异步下载,默认开启,网络不好时可以关闭,并发数量可在主函数16行修改",
 
     "proxy": "",
     "proxy_info": "手动配置代理,默认为空,非必要无需填写 格式: http://localhost:port ",
-
-    "orig_format": true,
-    "orig_format_info": "忽略 img_format 并依次尝试以 JPEG, PNG 格式下载原图 (name=orig) 。均下载错误后会退回使用 PNG name=4096x4096 进行下载)",
-
-    "orig_fail_alert": true,
-    "orig_fail_alert_info": "开启原图下载错误的提示",
 
     "(๑´ڡ`๑)": "info 是注释，凑合着看吧"
 }


### PR DESCRIPTION
settings.json 中新增选项:

- orig_format: 会忽略 img_format 并依次尝试以 JPEG, PNG 格式下载原图 (name=orig) ；均下载错误后会退回使用 PNG name=4096x4096 进行下载)
- orig_fail_alert: 开启原图下载错误的提示

main.py 通过返回状态码来判断是否下载成功，返回 404 则 raise Expection

与 @mrhso 交流了解到 Twitter 原图的抓取过程：

![](https://github.com/user-attachments/assets/e7213bdd-aa60-40cc-9167-c030394ce3f9)
